### PR TITLE
Update QA tooling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,14 @@
         "forum": "https://discourse.laminas.dev/"
     },
     "require": {
-        "php": "^7.4",
-        "psr/http-factory-implementation": "*"
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "psr/http-factory-implementation": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~2.0.0",
-        "laminas/laminas-diactoros": "^2.3",
-        "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.1",
-        "psr/container": "^1.0"
+        "laminas/laminas-coding-standard": "~2.5.0",
+        "laminas/laminas-diactoros": "^2.18.1",
+        "phpunit/phpunit": "^9.5.28",
+        "psr/container": "^1.0 || ^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -36,15 +35,15 @@
         }
     },
     "extra": {
-        "branch-alias": {
-            "dev-master": "1.0.x-dev"
-        },
         "laminas": {
             "config-provider": "Laminas\\Diactoros\\Serializer\\ConfigProvider"
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "scripts": {
         "cs-check": "phpcs",

--- a/docs/book/v1/usage.md
+++ b/docs/book/v1/usage.md
@@ -1,24 +1,18 @@
 # Usage
 
-This package provides serialization classes to convert
-[PSR-7 (HTTP Message)](https://www.php-fig.org/psr/psr-7/) request and response instances to
-and from arrays and strings, exposing the following classes:
+This package provides serialization classes to convert [PSR-7 (HTTP Message)](https://www.php-fig.org/psr/psr-7/) request and response instances to and from arrays and strings, exposing the following classes:
 
 - `Laminas\Diactoros\Serializer\Request\ArraySerializer`
 - `Laminas\Diactoros\Serializer\Request\StringSerializer`
 - `Laminas\Diactoros\Serializer\Response\ArraySerializer`
 - `Laminas\Diactoros\Serializer\Response\StringSerializer`
 
-Each uses relevant factories from [PSR-17 (HTTP Message Factories)](https://www.php-fig.org/psr/psr-17/)
-to deserialize to the relevant PSR-7 instances, based on the PSR-7
-implementation you have installed.
+Each uses relevant factories from [PSR-17 (HTTP Message Factories)](https://www.php-fig.org/psr/psr-17/) to deserialize to the relevant PSR-7 instances, based on the PSR-7 implementation you have installed.
 
 ## Serialize PSR-7 Requests to Arrays
 
-Sometimes you may want to keep the structure of an HTTP request when serializing
-it, to allow analyzing it more easily. For this purpose, we provide
-`Laminas\Diactoros\Serializer\Request\ArraySerializer`, which can both serialize
-to an array, as well as deserialize those arrays back to a PSR-7 request.
+Sometimes you may want to keep the structure of an HTTP request when serializing it, to allow analyzing it more easily.
+For this purpose, we provide `Laminas\Diactoros\Serializer\Request\ArraySerializer`, which can both serialize to an array, as well as deserialize those arrays back to a PSR-7 request.
 
 The array format it uses is as follows:
 
@@ -33,8 +27,7 @@ The array format it uses is as follows:
 ]
 ```
 
-The constructor for `Laminas\Diactoros\Serializer\Request\ArraySerializer`
-reads:
+The constructor for `Laminas\Diactoros\Serializer\Request\ArraySerializer` reads:
 
 ```php
 public function __construct(
@@ -80,11 +73,9 @@ assert($requestData == $serializer->toArray($request));
 
 ## Serialize PSR-7 Requests to Strings
 
-If you want to serialize your request to an actual string HTTP message, or
-parse an HTTP request into a PSR-7 instance, you can use
-`Laminas\Diactoros\Serializer\Request\StringSerializer`.
+If you want to serialize your request to an actual string HTTP message, or parse an HTTP request into a PSR-7 instance, you can use `Laminas\Diactoros\Serializer\Request\StringSerializer`.
 
-It's constructor reads:
+Its constructor reads:
 
 ```php
 public function __construct(
@@ -133,10 +124,7 @@ assert($message === $serializer->toString($request));
 
 ## Serialize PSR-7 Responses to Arrays
 
-Mirroring the functionality for [serializing requests to
-arrays](#serialize-psr-7-requests-to-arrays), we provide similar functionality
-for responses via the `Laminas\Diactoros\Serializer\Response\ArraySerializer`
-class.
+Mirroring the functionality for [serializing requests to arrays](#serialize-psr-7-requests-to-arrays), we provide similar functionality for responses via the `Laminas\Diactoros\Serializer\Response\ArraySerializer` class.
 
 The array format it uses is as follows:
 
@@ -150,8 +138,7 @@ The array format it uses is as follows:
 ]
 ```
 
-The constructor for `Laminas\Diactoros\Serializer\Response\ArraySerializer`
-reads:
+The constructor for `Laminas\Diactoros\Serializer\Response\ArraySerializer` reads:
 
 ```php
 public function __construct(
@@ -195,11 +182,9 @@ assert($responseData == $serializer->toArray($response));
 
 ## Serialize PSR-7 Responses to Strings
 
-If you want to serialize your response to an actual string HTTP message, or
-parse an HTTP response into a PSR-7 instance, you can use
-`Laminas\Diactoros\Serializer\Response\StringSerializer`.
+If you want to serialize your response to an actual string HTTP message, or parse an HTTP response into a PSR-7 instance, you can use `Laminas\Diactoros\Serializer\Response\StringSerializer`.
 
-It's constructor reads:
+Its constructor reads:
 
 ```php
 public function __construct(

--- a/docs/book/v1/usage.md
+++ b/docs/book/v1/usage.md
@@ -16,7 +16,7 @@ implementation you have installed.
 ## Serialize PSR-7 Requests to Arrays
 
 Sometimes you may want to keep the structure of an HTTP request when serializing
-it, to allow analyzing it more easily. For this purpose, we provide 
+it, to allow analyzing it more easily. For this purpose, we provide
 `Laminas\Diactoros\Serializer\Request\ArraySerializer`, which can both serialize
 to an array, as well as deserialize those arrays back to a PSR-7 request.
 
@@ -96,7 +96,7 @@ public function __construct(
 
 and it exposes the following methods:
 
-```
+```php
 public function fromString(string $message): Psr\Http\Message\RequestInterface
 public function fromStream(Psr\Http\Message\StreamInterface $stream): Psr\Http\Message\RequestInterface
 public function toString(Psr\Http\Message\RequestInterface $request): string
@@ -210,7 +210,7 @@ public function __construct(
 
 and it exposes the following methods:
 
-```
+```php
 public function fromString(string $message): Psr\Http\Message\ResponseInterface
 public function fromStream(Psr\Http\Message\StreamInterface $stream): Psr\Http\Message\ResponseInterface
 public function toString(Psr\Http\Message\ResponseInterface $response): string

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="./vendor/autoload.php"
+    colors="true">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+
     <testsuites>
         <testsuite name="laminas-diactoros-serializer">
             <directory>./test</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/AbstractStringSerializer.php
+++ b/src/AbstractStringSerializer.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Exception/DeserializationException.php
+++ b/src/Exception/DeserializationException.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Exception/InvalidStreamPointerPositionException.php
+++ b/src/Exception/InvalidStreamPointerPositionException.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Exception/SerializationException.php
+++ b/src/Exception/SerializationException.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/RelativeStream.php
+++ b/src/RelativeStream.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -34,6 +32,9 @@ final class RelativeStream implements StreamInterface
         $this->offset          = (int) $offset;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function __toString(): string
     {
         if ($this->isSeekable()) {
@@ -42,39 +43,57 @@ final class RelativeStream implements StreamInterface
         return $this->getContents();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function close(): void
     {
         $this->decoratedStream->close();
     }
 
-    // Disabling rules to avoid issues when inheriting signatures.
-    // phpcs:disable WebimpressCodingStandard.Functions.Param.MissingSpecification, WebimpressCodingStandard.Functions.ReturnType.ReturnValue
-
+    /**
+     * {@inheritdoc}
+     */
     public function detach()
     {
         return $this->decoratedStream->detach();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getSize(): int
     {
         return $this->decoratedStream->getSize() - $this->offset;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function tell(): int
     {
         return $this->decoratedStream->tell() - $this->offset;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function eof(): bool
     {
         return $this->decoratedStream->eof();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function isSeekable(): bool
     {
         return $this->decoratedStream->isSeekable();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function seek($offset, $whence = SEEK_SET): void
     {
         if ($whence === SEEK_SET) {
@@ -84,16 +103,25 @@ final class RelativeStream implements StreamInterface
         $this->decoratedStream->seek($offset, $whence);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function rewind(): void
     {
         $this->seek(0);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function isWritable(): bool
     {
         return $this->decoratedStream->isWritable();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function write($string): int
     {
         if ($this->tell() < 0) {
@@ -102,11 +130,17 @@ final class RelativeStream implements StreamInterface
         return $this->decoratedStream->write($string);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function isReadable(): bool
     {
         return $this->decoratedStream->isReadable();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function read($length): string
     {
         if ($this->tell() < 0) {
@@ -115,6 +149,9 @@ final class RelativeStream implements StreamInterface
         return $this->decoratedStream->read($length);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getContents(): string
     {
         if ($this->tell() < 0) {
@@ -123,10 +160,11 @@ final class RelativeStream implements StreamInterface
         return $this->decoratedStream->getContents();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getMetadata($key = null)
     {
         return $this->decoratedStream->getMetadata($key);
     }
-
-    // phpcs:enable
 }

--- a/src/Request/ArraySerializer.php
+++ b/src/Request/ArraySerializer.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Request/ArraySerializerFactory.php
+++ b/src/Request/ArraySerializerFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Request/StringSerializer.php
+++ b/src/Request/StringSerializer.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Request/StringSerializerFactory.php
+++ b/src/Request/StringSerializerFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Response/ArraySerializer.php
+++ b/src/Response/ArraySerializer.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Response/ArraySerializerFactory.php
+++ b/src/Response/ArraySerializerFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Response/StringSerializer.php
+++ b/src/Response/StringSerializer.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Response/StringSerializerFactory.php
+++ b/src/Response/StringSerializerFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/test/RelativeStreamTest.php
+++ b/test/RelativeStreamTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -12,9 +10,8 @@ namespace LaminasTest\Diactoros\Serializer;
 
 use Laminas\Diactoros\Serializer\RelativeStream;
 use Laminas\Diactoros\Stream;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
 use RuntimeException;
 
 use const SEEK_SET;
@@ -24,144 +21,157 @@ use const SEEK_SET;
  */
 class RelativeStreamTest extends TestCase
 {
-    use ProphecyTrait;
-
     public function testToString()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->isSeekable()->willReturn(true);
-        $decorated->tell()->willReturn(100);
-        $decorated->seek(100, SEEK_SET)->shouldBeCalled();
-        $decorated->getContents()->shouldBeCalled()->willReturn('foobarbaz');
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->any())->method('isSeekable')->willReturn(true);
+        $decorated->expects($this->any())->method('tell')->willReturn(100);
+        $decorated->expects($this->any())->method('seek')->with(100, SEEK_SET);
+        $decorated->expects($this->once())->method('getContents')->willReturn('foobarbaz');
 
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        $stream = new RelativeStream($decorated, 100);
         $ret    = $stream->__toString();
         $this->assertSame('foobarbaz', $ret);
     }
 
     public function testClose()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->close()->shouldBeCalled();
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->once())->method('close');
+        $stream = new RelativeStream($decorated, 100);
         $stream->close();
     }
 
     public function testDetach()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->detach()->shouldBeCalled()->willReturn(250);
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->once())->method('detach')->willReturn(250);
+        $stream = new RelativeStream($decorated, 100);
         $ret    = $stream->detach();
         $this->assertSame(250, $ret);
     }
 
     public function testGetSize()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->getSize()->shouldBeCalled()->willReturn(250);
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->once())->method('getSize')->willReturn(250);
+        $stream = new RelativeStream($decorated, 100);
         $ret    = $stream->getSize();
         $this->assertSame(150, $ret);
     }
 
     public function testTell()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->tell()->shouldBeCalled()->willReturn(188);
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->once())->method('tell')->willReturn(188);
+        $stream = new RelativeStream($decorated, 100);
         $ret    = $stream->tell();
         $this->assertSame(88, $ret);
     }
 
     public function testIsSeekable()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->isSeekable()->shouldBeCalled()->willReturn(true);
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->once())->method('isSeekable')->willReturn(true);
+        $stream = new RelativeStream($decorated, 100);
         $ret    = $stream->isSeekable();
         $this->assertSame(true, $ret);
     }
 
     public function testIsWritable()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->isWritable()->shouldBeCalled()->willReturn(true);
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->once())->method('isWritable')->willReturn(true);
+        $stream = new RelativeStream($decorated, 100);
         $ret    = $stream->isWritable();
         $this->assertSame(true, $ret);
     }
 
     public function testIsReadable()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->isReadable()->shouldBeCalled()->willReturn(false);
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->once())->method('isReadable')->willReturn(false);
+        $stream = new RelativeStream($decorated, 100);
         $ret    = $stream->isReadable();
         $this->assertSame(false, $ret);
     }
 
     public function testSeek()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->seek(126, SEEK_SET)->shouldBeCalled();
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->once())->method('seek')->with(126, SEEK_SET);
+        $stream = new RelativeStream($decorated, 100);
         $this->assertNull($stream->seek(26));
     }
 
     public function testRewind()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->seek(100, SEEK_SET)->shouldBeCalled();
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->once())->method('seek')->with(100, SEEK_SET);
+        $stream = new RelativeStream($decorated, 100);
         $this->assertNull($stream->rewind());
     }
 
     public function testWrite()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->tell()->willReturn(100);
-        $decorated->write("foobaz")->shouldBeCalled()->willReturn(6);
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->once())->method('tell')->willReturn(100);
+        $decorated->expects($this->once())->method('write')->with('foobaz')->willReturn(6);
+        $stream = new RelativeStream($decorated, 100);
         $ret    = $stream->write("foobaz");
         $this->assertSame(6, $ret);
     }
 
     public function testRead()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->tell()->willReturn(100);
-        $decorated->read(3)->shouldBeCalled()->willReturn("foo");
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->once())->method('tell')->willReturn(100);
+        $decorated->expects($this->once())->method('read')->with(3)->willReturn('foo');
+        $stream = new RelativeStream($decorated, 100);
         $ret    = $stream->read(3);
         $this->assertSame("foo", $ret);
     }
 
     public function testGetContents()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->tell()->willReturn(100);
-        $decorated->getContents()->shouldBeCalled()->willReturn("foo");
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->once())->method('tell')->willReturn(100);
+        $decorated->expects($this->once())->method('getContents')->willReturn('foo');
+        $stream = new RelativeStream($decorated, 100);
         $ret    = $stream->getContents();
         $this->assertSame("foo", $ret);
     }
 
     public function testGetMetadata()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->getMetadata("bar")->shouldBeCalled()->willReturn("foo");
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->once())->method('getMetadata')->with('bar')->willReturn('foo');
+        $stream = new RelativeStream($decorated, 100);
         $ret    = $stream->getMetadata("bar");
         $this->assertSame("foo", $ret);
     }
 
     public function testWriteRaisesExceptionWhenPointerIsBehindOffset()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->tell()->shouldBeCalled()->willReturn(0);
-        $decorated->write("foobaz")->shouldNotBeCalled();
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->once())->method('tell')->willReturn(0);
+        $decorated->expects($this->never())->method('write')->with('foobaz');
+        $stream = new RelativeStream($decorated, 100);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Invalid pointer position');
@@ -171,10 +181,11 @@ class RelativeStreamTest extends TestCase
 
     public function testReadRaisesExceptionWhenPointerIsBehindOffset()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->tell()->shouldBeCalled()->willReturn(0);
-        $decorated->read(3)->shouldNotBeCalled();
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->once())->method('tell')->willReturn(0);
+        $decorated->expects($this->never())->method('read')->with(3);
+        $stream = new RelativeStream($decorated, 100);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Invalid pointer position');
@@ -184,10 +195,11 @@ class RelativeStreamTest extends TestCase
 
     public function testGetContentsRaisesExceptionWhenPointerIsBehindOffset()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->tell()->shouldBeCalled()->willReturn(0);
-        $decorated->getContents()->shouldNotBeCalled();
-        $stream = new RelativeStream($decorated->reveal(), 100);
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->once())->method('tell')->willReturn(0);
+        $decorated->expects($this->never())->method('getContents');
+        $stream = new RelativeStream($decorated, 100);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Invalid pointer position');
@@ -197,13 +209,14 @@ class RelativeStreamTest extends TestCase
 
     public function testCanReadContentFromNotSeekableResource()
     {
-        $decorated = $this->prophesize(Stream::class);
-        $decorated->isSeekable()->willReturn(false);
-        $decorated->seek(Argument::any())->shouldNotBeCalled();
-        $decorated->tell()->willReturn(3);
-        $decorated->getContents()->willReturn('CONTENTS');
+        /** @var Stream&MockObject $decorated */
+        $decorated = $this->createMock(Stream::class);
+        $decorated->expects($this->any())->method('isSeekable')->willReturn(false);
+        $decorated->expects($this->never())->method('seek');
+        $decorated->expects($this->once())->method('tell')->willReturn(3);
+        $decorated->expects($this->once())->method('getContents')->willReturn('CONTENTS');
 
-        $stream = new RelativeStream($decorated->reveal(), 3);
+        $stream = new RelativeStream($decorated, 3);
         $this->assertSame('CONTENTS', $stream->__toString());
     }
 }

--- a/test/Request/ArraySerializerFactoryTest.php
+++ b/test/Request/ArraySerializerFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/test/Request/ArraySerializerTest.php
+++ b/test/Request/ArraySerializerTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/test/Request/StringSerializerFactoryTest.php
+++ b/test/Request/StringSerializerFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/test/Request/StringSerializerTest.php
+++ b/test/Request/StringSerializerTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -19,8 +17,8 @@ use Laminas\Diactoros\Stream;
 use Laminas\Diactoros\StreamFactory;
 use Laminas\Diactoros\Uri;
 use Laminas\Diactoros\UriFactory;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 use UnexpectedValueException;
@@ -309,7 +307,7 @@ class StringSerializerTest extends TestCase
 
     public function testFromStreamThrowsExceptionWhenStreamIsNotReadable(): void
     {
-        /** @var StreamInterface|ObjectProphecy $stream */
+        /** @var StreamInterface&MockObject $stream */
         $stream = $this->createMock(StreamInterface::class);
         $stream
             ->expects($this->once())
@@ -323,7 +321,7 @@ class StringSerializerTest extends TestCase
 
     public function testFromStreamThrowsExceptionWhenStreamIsNotSeekable(): void
     {
-        /** @var StreamInterface|ObjectProphecy $stream */
+        /** @var StreamInterface&MockObject $stream */
         $stream = $this->createMock(StreamInterface::class);
         $stream
             ->expects($this->once())
@@ -344,7 +342,7 @@ class StringSerializerTest extends TestCase
         $headers = "POST /foo HTTP/1.0\r\nContent-Type: text/plain\r\nX-Foo-Bar: Baz;\r\n Bat\r\n\r\n";
         $payload = $headers . "Content!";
 
-        /** @var StreamInterface|ObjectProphecy $stream */
+        /** @var StreamInterface&MockObject $stream */
         $stream = $this->createMock(StreamInterface::class);
         $stream
             ->expects($this->once())

--- a/test/Response/ArraySerializerFactoryTest.php
+++ b/test/Response/ArraySerializerFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/test/Response/ArraySerializerTest.php
+++ b/test/Response/ArraySerializerTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/test/Response/StringSerializerFactoryTest.php
+++ b/test/Response/StringSerializerFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/test/Response/StringSerializerTest.php
+++ b/test/Response/StringSerializerTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-diactoros-serializer for the canonical source repository
- * @copyright https://github.com/laminas/laminas-diactoros-serializer/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-diactoros-serializer/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -15,8 +13,8 @@ use Laminas\Diactoros\Response;
 use Laminas\Diactoros\ResponseFactory;
 use Laminas\Diactoros\Serializer\Response\StringSerializer;
 use Laminas\Diactoros\StreamFactory;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use UnexpectedValueException;
@@ -224,7 +222,7 @@ class StringSerializerTest extends TestCase
 
     public function testFromStreamThrowsExceptionWhenStreamIsNotReadable(): void
     {
-        /** @var StreamInterface|ObjectProphecy $stream */
+        /** @var StreamInterface&MockObject $stream */
         $stream = $this->createMock(StreamInterface::class);
         $stream
             ->expects($this->once())
@@ -238,7 +236,7 @@ class StringSerializerTest extends TestCase
 
     public function testFromStreamThrowsExceptionWhenStreamIsNotSeekable(): void
     {
-        /** @var StreamInterface|ObjectProphecy $stream */
+        /** @var StreamInterface&MockObject $stream */
         $stream = $this->createMock(StreamInterface::class);
         $stream
             ->expects($this->once())


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Updates to more recent versions of laminas-coding-standard and PHPUnit, and the updates the code to work with them:

- Ran phpcbf, and then fixed all remaining CS issues manually.
- Stripped out usage of Prophecy, and replaced with native PHPUnit mocks.
